### PR TITLE
Accept failOnMatch threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,11 @@ Use `0` to disable.
 
 ### options.failOnMatch
 
-Type: `boolean`
+Type: `boolean|number`
 
 Default value: `'true'`
+
+Use a number as a threshold (e.g. use `42` to pass for 41 matches but fail beyond 42 matches).
 
 
 ## License

--- a/tasks/jsinspect.js
+++ b/tasks/jsinspect.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
           taskSucceeded = false;
         }
       });
-    } else if (options.failOnMatch) {
+    } else if (options.failOnMatch === true) {
       // Handle failOnMatch boolean
       inspector.on('match', function() {
         taskSucceeded = false;

--- a/tasks/jsinspect.js
+++ b/tasks/jsinspect.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('jsinspect', 'Grunt task for jsinspect', function() {
     var done = this.async();
     var taskSucceeded = true;
+    var nbOfMatches = 0;
 
     var options = this.options({
       threshold:   30,
@@ -45,7 +46,16 @@ module.exports = function(grunt) {
       suppress: options.suppress
     });
 
-    if (options.failOnMatch) {
+    if (typeof options.failOnMatch === 'number') {
+      // Handle failOnMatch threshold.
+      inspector.on('match', function() {
+        nbOfMatches++;
+        if (nbOfMatches >= options.failOnMatch) {
+          taskSucceeded = false;
+        }
+      });
+    } else if (options.failOnMatch) {
+      // Handle failOnMatch boolean
       inspector.on('match', function() {
         taskSucceeded = false;
       });

--- a/test/fixtures/two-duplicates.js
+++ b/test/fixtures/two-duplicates.js
@@ -1,0 +1,13 @@
+var originalMethod = function () {
+  return "abc";
+};
+var secondMethod = function () {
+  return "abc";
+};
+
+var firstPattern = function () {
+  return this;
+};
+var secondPattern = function () {
+  return this;
+};

--- a/test/jsinspect_test.js
+++ b/test/jsinspect_test.js
@@ -210,6 +210,44 @@ exports.jsinspect = {
             test.done();
           }
         );
+      },
+
+      succeedOnThresholdMatch: function(test) {
+        runTask(
+          'jsinspect:test',
+          {
+            test: {
+              options: {
+                failOnMatch: 3,
+                threshold: 5
+              },
+              src: ['test/fixtures/two-duplicates.js']
+            }
+          },
+          function(error) {
+            test.strictEqual(typeof error, 'undefined');
+            test.done();
+          }
+        );
+      },
+
+      failOnThresholdMatch: function(test) {
+        runTask(
+          'jsinspect:test',
+          {
+            test: {
+              options: {
+                failOnMatch: 2,
+                threshold: 5
+              },
+              src: ['test/fixtures/two-duplicates.js']
+            }
+          },
+          function(error) {
+            test.strictEqual(error instanceof Error, true);
+            test.done();
+          }
+        );
       }
     }
   }


### PR DESCRIPTION
Hi there!

First of all, thanks a lot for this useful grunt plugin. That gives us the possibility to add a `jsinspect` step to our CI process with ease.

---

Unfortunately, I wanted to add it to an existing project, which already has a few duplicate matches after inspection. We don't have time to fix all of them right away, but I'd like to implement `jsinspect` to ensure we won't go worse. The idea is to clean all of this incrementally.

Hence, the `failOnMatch` boolean didn't fit this scenario quite well:

- if it's `false` it never triggers any error, which would make this step useless in a CI process
- if it's `true`, then we have to clean all of the codebase before

That's why I forked to give the possibility to use a `number` along with a `boolean`. A number represents a threshold of matches: once you've reached the given number, it triggers an error, but not before.

You can still pass a `boolean` as it still make sense + ensure retro-compatibility.

Added unit tests & documentation, so here's the PR. Please let me know if I did anything wrong :smiley: 