### PR TITLE
Migrate to a recent jsinspect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4.2"
   - "6"
+  - "8"
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ grunt.initConfig({
   jsinspect: {
     examples: {
       options: {
-        threshold:   30,
-        diff:        true,
-        identifiers: false,
-        failOnMatch: true,
-        suppress:    100,
-        reporter:    'default',
-        configFile:  '.jsinspectrc'
+        threshold:     30,
+        diff:          true,
+        identifiers:   false,
+        failOnMatch:   true,
+        truncate:      100,
+        reporter:      'default',
+        debug:         false,
+        configFile:    '.jsinspectrc'
       },
       src: [
         '**/*.js'
@@ -106,11 +107,11 @@ The configuration file should be valid JSON, but can contain comments, which are
 
 ```js
 {
-  "threshold":     30,
-  "identifiers":   true,
-  "ignore":        "Test.js|Spec.js", // used as RegExp,
-  "reporter":      "json",
-  "suppress":      100
+  "threshold":       30,
+  "noIdentifiers":   true,
+  "ignore":          "Test.js|Spec.js", // used as RegExp,
+  "reporter":        "json",
+  "truncate":        100
 }
 ```
 
@@ -165,7 +166,7 @@ The destination directory must already exist.
 You’ll probably want to pick a file extension which corresponds with the chosen [reporter](#reporter).
 
 
-### options.suppress
+### options.truncate
 
 Type: `number`
 
@@ -187,4 +188,3 @@ Use a number as a threshold (e.g. use `42` to pass for 41 matches but fail beyon
 ## License
 
 Copyright (c) Stefan Judis and Juga Paazmaya, licensed under [the MIT license](LICENSE-MIT)
-

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ grunt.initConfig({
   jsinspect: {
     examples: {
       options: {
-        threshold:     30,
-        diff:          true,
-        identifiers:   false,
-        failOnMatch:   true,
-        truncate:      100,
-        reporter:      'default',
-        debug:         false,
-        configFile:    '.jsinspectrc'
+        threshold:    30,
+        identifiers:  false,
+        literals:     true,
+        truncate:     100,
+        minInstances: 2,
+        reporter:     'default',
+        failOnMatch:  true,
+        configFile:   '.jsinspectrc'
       },
       src: [
         '**/*.js'
@@ -107,11 +107,11 @@ The configuration file should be valid JSON, but can contain comments, which are
 
 ```js
 {
-  "threshold":       30,
-  "noIdentifiers":   true,
-  "ignore":          "Test.js|Spec.js", // used as RegExp,
-  "reporter":        "json",
-  "truncate":        100
+  "threshold":     30,
+  "identifiers":   true,
+  "ignore":        "Test.js|Spec.js", // used as RegExp,
+  "reporter":      "json",
+  "truncate":      100
 }
 ```
 
@@ -123,13 +123,6 @@ Type: `number`
 Default value: `30`
 
 Number of nodes
-
-
-### options.diff
-
-Type: `boolean`
-
-Default value: `true`
 
 
 ### options.identifiers

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Getting Started
 
 This plugin requires Grunt version `>=0.4.0`, verbally the minimum of `0.4.0`.
-The minimum Node.js version supported is [`4.2.0` (the first LTS version)](https://nodejs.org/en/blog/release/v4.2.0/).
+The minimum Node.js version supported is [`6.9.0` (the second LTS version)](https://nodejs.org/en/blog/release/v6.9.0/).
 
 If you haven’t used [Grunt](http://gruntjs.com/) before, be sure to check out the
 [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to

--- a/README.md
+++ b/README.md
@@ -40,14 +40,18 @@ grunt.initConfig({
   jsinspect: {
     examples: {
       options: {
-        threshold:    30,
+        // jsinspect specific options
         identifiers:  false,
         literals:     true,
-        truncate:     100,
         minInstances: 2,
         reporter:     'default',
+        threshold:    30,
+        truncate:     100,
+
+        // options used for grunt-jsinspect
+        configFile:   '.jsinspectrc',
         failOnMatch:  true,
-        configFile:   '.jsinspectrc'
+        outputPath:   undefined
       },
       src: [
         '**/*.js'
@@ -116,22 +120,24 @@ The configuration file should be valid JSON, but can contain comments, which are
 ```
 
 
-### options.threshold
+### options.failOnMatch
 
-Type: `number`
+Type: `boolean|number`
 
-Default value: `30`
+Default value: `true`
 
-Number of nodes
+Use a number as a threshold (e.g. use `42` to pass for 41 matches but fail beyond 42 matches).
 
 
-### options.identifiers
+### options.outputPath
 
-Type: `boolean`
+Type: `string`
 
-Default value: `false`
+Default value: `undefined`
 
-Match identifiers
+Specify the path of the output file.
+The destination directory must already exist.
+You’ll probably want to pick a file extension which corresponds with the chosen [reporter](#reporter).
 
 
 ### options.reporter
@@ -148,35 +154,21 @@ Please see the
 file of the `jsinspect` project in order to find out about the existing reporters.
 
 
-### options.outputPath
+### Other options passed directly to `jsinspect`
 
-Type: `string`
+Code inspector specific options:
 
-Default value: `undefined`
+* `threshold`, type `number`, defaults to `30`
+* `literals`, type `boolean`, defaults to ``
+* `minInstances`, type `number`, defaults to `2`
+* `identifiers`, type `boolean`, defaults to `false`
 
-Specify the path of the output file.
-The destination directory must already exist.
-You’ll probably want to pick a file extension which corresponds with the chosen [reporter](#reporter).
+Options passed to the selected reporter:
 
+* `truncate`, type `number`, defaults to `100`
+* `identifiers`, type `boolean`, defaults to `false`
 
-### options.truncate
-
-Type: `number`
-
-Default value: `100`
-
-Length to suppress diffs.
-Use `0` to disable.
-
-
-### options.failOnMatch
-
-Type: `boolean|number`
-
-Default value: `true`
-
-Use a number as a threshold (e.g. use `42` to pass for 41 matches but fail beyond 42 matches).
-
+For further details about each of these options, [see the `jsinspect` documentation](https://github.com/danielstjules/jsinspect#usage).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "grunt -- test"
   },
   "engines": {
-    "node": ">=4.2.0"
+    "node": ">=6.9.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "inspect"
   ],
   "dependencies": {
-    "jsinspect": "^0.8.0",
+    "jsinspect": "^0.12.6",
     "strip-json-comments": "^2.0.1"
   }
 }

--- a/tasks/jsinspect.js
+++ b/tasks/jsinspect.js
@@ -25,8 +25,9 @@ module.exports = function(grunt) {
       diff:        true,
       identifiers: false,
       failOnMatch: true,
-      suppress:    100,
+      truncate:    100,
       reporter:    'default',
+      debug:       false,
       configFile:  '.jsinspectrc'
     });
 
@@ -81,7 +82,7 @@ module.exports = function(grunt) {
     this.reporterType = new Reporter[options.reporter](inspector, {
       writableStream: writableStream,
       diff: options.diff,
-      suppress: options.suppress
+      identifiers: options.identifiers
     });
 
     if (typeof options.failOnMatch === 'number') {

--- a/tasks/jsinspect.js
+++ b/tasks/jsinspect.js
@@ -21,14 +21,17 @@ module.exports = function(grunt) {
     let nbOfMatches = 0;
 
     const options = this.options({
-      threshold:   30,
-      diff:        true,
-      identifiers: false,
-      failOnMatch: true,
-      truncate:    100,
-      reporter:    'default',
-      debug:       false,
-      configFile:  '.jsinspectrc'
+      // jsinspect options
+      threshold:    30,
+      identifiers:  false,
+      literals:     true,
+      truncate:     100,
+      minInstances: 2,
+      reporter:     'default',
+
+      // options used for grunt-jsinspect
+      failOnMatch:  true,
+      configFile:   '.jsinspectrc'
     });
 
     let configStat;
@@ -55,9 +58,10 @@ module.exports = function(grunt) {
     }
 
     const inspector = new Inspector(this.filesSrc, {
-      threshold:   options.threshold,
-      diff:        options.diff,
-      identifiers: options.identifiers
+      threshold:    options.threshold,
+      literals:     options.literals,
+      minInstances: options.minInstances,
+      identifiers:  options.identifiers
     });
 
     if (!Reporter.hasOwnProperty(options.reporter) ||
@@ -81,7 +85,7 @@ module.exports = function(grunt) {
 
     this.reporterType = new Reporter[options.reporter](inspector, {
       writableStream: writableStream,
-      diff: options.diff,
+      truncate: options.truncate,
       identifiers: options.identifiers
     });
 

--- a/tasks/jsinspect.js
+++ b/tasks/jsinspect.js
@@ -21,17 +21,18 @@ module.exports = function(grunt) {
     let nbOfMatches = 0;
 
     const options = this.options({
-      // jsinspect options
-      threshold:    30,
+      // jsinspect specific options
       identifiers:  false,
       literals:     true,
-      truncate:     100,
       minInstances: 2,
       reporter:     'default',
+      threshold:    30,
+      truncate:     100,
 
       // options used for grunt-jsinspect
+      configFile:   '.jsinspectrc',
       failOnMatch:  true,
-      configFile:   '.jsinspectrc'
+      outputPath:   undefined
     });
 
     let configStat;


### PR DESCRIPTION
Fixes #42.

Will still be needing to document new properties, or just point them to `jsinspect` documentation.